### PR TITLE
YC service discovery configuration password_from_env parameter

### DIFF
--- a/deploy/pgscv.yaml
+++ b/deploy/pgscv.yaml
@@ -16,6 +16,7 @@
 #      - authorized_key: /path/to/secret/authorized_key.json
 #        folder_id: "b1000000000000"
 #        password: "password"
+#        password_from_env: DB_PASSWORD
 #        user: "postgres_exporter"
 #        refresh_interval: 5
 #        clusters:

--- a/internal/discovery/service/yandex.go
+++ b/internal/discovery/service/yandex.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"maps"
+	"os"
 	"sync"
 	"time"
 
@@ -27,6 +28,7 @@ type YandexConfig struct {
 	FolderID        string    `json:"folder_id" yaml:"folder_id"`
 	User            string    `json:"user" yaml:"user"`
 	Password        string    `json:"password" yaml:"password"`
+	PasswordFromEnv string    `json:"password_from_env" yaml:"password_from_env"`
 	RefreshInterval int       `json:"refresh_interval" yaml:"refresh_interval"`
 	Clusters        []cluster `json:"clusters" yaml:"clusters"`
 }
@@ -203,6 +205,11 @@ func ensureConfigYandexMDB(config config) ([]YandexConfig, error) {
 	err = yaml.Unmarshal(o, c)
 	if err != nil {
 		return nil, err
+	}
+	for i, yc := range *c {
+		if yc.PasswordFromEnv != "" {
+			(*c)[i].Password = os.Getenv(yc.PasswordFromEnv)
+		}
 	}
 	return *c, nil
 }


### PR DESCRIPTION
The Yandex Cloud service discovery configuration now includes a password_from_env parameter, allowing for the creation of a more secure configuration file