### PR TITLE
Fix MultiXact wraparound calculation by using mxid_age() instead of a…

### DIFF
--- a/internal/collector/postgres_database.go
+++ b/internal/collector/postgres_database.go
@@ -51,7 +51,7 @@ const (
 		"FROM pg_stat_database WHERE datname IN (SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate) " +
 		"OR datname IS NULL"
 
-	xidLimitQuery = "SELECT 'database' AS src, 2147483647 - GREATEST(MAX(AGE(datfrozenxid)), MAX(AGE(COALESCE(NULLIF(datminmxid, 1), datfrozenxid)))) AS to_limit FROM pg_database " +
+	xidLimitQuery = "SELECT 'database' AS src, 2147483647 - GREATEST(MAX(AGE(datfrozenxid)), MAX(MXID_AGE(COALESCE(NULLIF(datminmxid, 1), datfrozenxid)))) AS to_limit FROM pg_database " +
 		"UNION SELECT 'prepared_xacts' AS src, 2147483647 - COALESCE(MAX(AGE(transaction)), 0) AS to_limit FROM pg_prepared_xacts " +
 		"UNION SELECT 'replication_slots' AS src, 2147483647 - GREATEST(COALESCE(MIN(AGE(xmin)), 0), COALESCE(MIN(AGE(catalog_xmin)), 0)) AS to_limit FROM pg_replication_slots"
 )

--- a/internal/collector/postgres_database.go
+++ b/internal/collector/postgres_database.go
@@ -51,7 +51,7 @@ const (
 		"FROM pg_stat_database WHERE datname IN (SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate) " +
 		"OR datname IS NULL"
 
-	xidLimitQuery = "SELECT 'database' AS src, 2147483647 - GREATEST(MAX(AGE(datfrozenxid)), MAX(MXID_AGE(COALESCE(NULLIF(datminmxid, 1), datfrozenxid)))) AS to_limit FROM pg_database " +
+	xidLimitQuery = "SELECT 'database' AS src, 2147483647 - GREATEST(MAX(AGE(datfrozenxid)), COALESCE(MAX(MXID_AGE(NULLIF(datminmxid, 1))), MAX(AGE(datfrozenxid)))) AS to_limit FROM pg_database " +
 		"UNION SELECT 'prepared_xacts' AS src, 2147483647 - COALESCE(MAX(AGE(transaction)), 0) AS to_limit FROM pg_prepared_xacts " +
 		"UNION SELECT 'replication_slots' AS src, 2147483647 - GREATEST(COALESCE(MIN(AGE(xmin)), 0), COALESCE(MIN(AGE(catalog_xmin)), 0)) AS to_limit FROM pg_replication_slots"
 )


### PR DESCRIPTION
…ge()

Description
This PR fixes an incorrect calculation in the postgres_xacts_left_before_wraparound metric related to MultiXact IDs. Currently, the query uses the age() function for values derived from datminmxid. However, according to the PostgreSQL documentation, age() is intended for transaction IDs (XID) and must not be used for MultiXact IDs (MXID).

PostgreSQL provides a dedicated function for this purpose: "mxid_age (xid) → integer
Returns the number of multixact IDs between the supplied multixact ID and the current multixacts counter." — PostgreSQL Documentation - https://www.postgresql.org/docs/14/functions-info.html

Using age(datminmxid) results in incorrect values because it implicitly treats a MultiXact ID as a transaction ID, which leads to inflated ages and false wraparound alerts.

This PR replaces age() with mxid_age() for the MultiXact-related part of the metric, which aligns the calculation with PostgreSQL documentation and eliminates false positives.